### PR TITLE
Add Canvas Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,28 @@ This agent provides tools for interacting with a FHIR server using PhenoML's lan
 
 3. Authenticate and set up environment variables:
 
-   a. **Obtain PhenoML Token**:
+   a. **Set .env credentials**:
+   Open the file `agents/.env` in your text editor of choice and set your
+PhenoML credentials and either Medplum or Canvas credentials based on which
+EMR you have chosen.
+
+   b. **Obtain PhenoML Token**:
    ```bash
    # Run the PhenoML authentication script with --save flag to save to .env automatically. Assumes your credentials are in your .env already 
    python auth/phenoml_auth.py --save
    ```
 
-   b. **Obtain Medplum Token**:
+   c. **Obtain Medplum Token** (if using Medplum):
    ```bash
    # Run the Medplum authentication script with --save flag to save to .env automatically. Assumes your credentials are in your .env already
    python3 auth/medplum_auth.py --save
+
+   ```
+
+   d. **Obtain Canvas Token** (if using Canvas):
+   ```bash
+   # Run the Canvas authentication script with --save flag to save to .env automatically. Assumes your credentials are in your .env already
+   python3 auth/canvas_auth.py --save
 
    ```
 

--- a/agents/.env
+++ b/agents/.env
@@ -1,0 +1,23 @@
+# Your PhenoML credentials
+PHENOML_IDENTITY=
+PHENOML_PASSWORD=
+
+# Leave this empty, the auth script can fill it in for you!
+PHENOML_TOKEN=
+
+# Your Medplum credentials
+MEDPLUM_CLIENT_ID=
+MEDPLUM_CLIENT_SECRET=
+
+# Leave this empty, the auth script can fill it in for you!
+MEDPLUM_TOKEN=
+
+# Your Canvas credentials and instance identifier
+CANVAS_CLIENT_ID=
+CANVAS_CLIENT_SECRET=
+CANVAS_INSTANCE_IDENTIFIER=
+
+# Leave this empty, the auth script can fill it in for you!
+CANVAS_TOKEN=
+
+

--- a/agents/auth/canvas_auth.py
+++ b/agents/auth/canvas_auth.py
@@ -8,7 +8,7 @@ import requests
 import argparse
 from dotenv import load_dotenv
 
-def canvas_authenticate(client_id=None, client_secret=None, canvas_base_url=None):
+def canvas_authenticate(client_id=None, client_secret=None, canvas_instance_identifier=None):
     """
     Authenticate with Canvas API and get a token.
     
@@ -25,9 +25,9 @@ def canvas_authenticate(client_id=None, client_secret=None, canvas_base_url=None
     # Use provided credentials or get from environment
     client_id = client_id or os.environ.get("CANVAS_CLIENT_ID")
     client_secret = client_secret or os.environ.get("CANVAS_CLIENT_SECRET")
-    canvas_base_url = canvas_base_url or os.environ.get("CANVAS_BASE_URL")
+    canvas_instance_identifier = canvas_instance_identifier or os.environ.get("CANVAS_INSTANCE_IDENTIFIER")
     
-    if not client_id or not client_secret:
+    if not client_id or not client_secret or not canvas_instance_identifier:
         return {
             "status": "error",
             "error_message": "Canvas credentials not found. Please provide client ID/secret or set environment variables."
@@ -35,7 +35,7 @@ def canvas_authenticate(client_id=None, client_secret=None, canvas_base_url=None
     
     try:
         # Authenticate with Canvas
-        auth_url = f"{canvas_base_url}/auth/token/"
+        auth_url = f"https://{canvas_instance_identifier}.canvasmedical.com/auth/token/"
         payload = {
             "grant_type": "client_credentials",
             "client_id": client_id,
@@ -78,11 +78,12 @@ def main():
     parser = argparse.ArgumentParser(description="Authenticate with Canvas API")
     parser.add_argument("--client-id", help="Canvas client ID")
     parser.add_argument("--client-secret", help="Canvas client secret")
+    parser.add_argument("--instance-identifier", help="Canvas instance identifier")
     parser.add_argument("--save", action="store_true", help="Save token to .env file")
     args = parser.parse_args()
     
     # Authenticate with provided credentials or environment variables
-    result = canvas_authenticate(args.client_id, args.client_secret)
+    result = canvas_authenticate(args.client_id, args.client_secret, args.instance_identifier)
     
     if result["status"] == "success":
         token = result["token"]
@@ -96,20 +97,32 @@ def main():
             env_file = ".env"
             
             # Read existing .env file if it exists
-            env_vars = {}
+            # Store all lines faithfully, unless it is a line for CANVAS_TOKEN.
+            # In that case, store a replacement line with the new token value.
+            # If none of the lines were for the CANVAS_TOKEN, append it to the
+            # end.
+            env_file_lines = []
+            canvas_token_line_set = False
             if os.path.exists(env_file):
                 with open(env_file, "r") as f:
                     for line in f:
-                        if "=" in line and not line.startswith("#"):
+                        if line.startswith("#") or line.strip() == "":
+                            env_file_lines.append(line)
+                        elif "=" in line:
                             key, value = line.strip().split("=", 1)
-                            env_vars[key] = value
+                            if key == "CANVAS_TOKEN":
+                                updated_token_line = f"CANVAS_TOKEN={token}\n"
+                                env_file_lines.append(updated_token_line)
+                                canvas_token_line_set = True
+                            else:
+                                env_file_lines.append(line)
+            if not canvas_token_line_set:
+                env_file_lines.append(f"CANVAS_TOKEN={token}\n")
             
-            # Update token and write back
-            env_vars["CANVAS_TOKEN"] = token
-            
+            # Write the updated env file
             with open(env_file, "w") as f:
-                for key, value in env_vars.items():
-                    f.write(f"{key}={value}\n")
+                for line in env_file_lines:
+                    f.write(f"{line}")
             
             print(f"Token saved to {env_file}")
     else:
@@ -119,4 +132,4 @@ def main():
     return 0
 
 if __name__ == "__main__":
-    exit(main()) 
+    exit(main())

--- a/agents/auth/medplum_auth.py
+++ b/agents/auth/medplum_auth.py
@@ -94,20 +94,32 @@ def main():
             env_file = ".env"
             
             # Read existing .env file if it exists
-            env_vars = {}
+            # Store all lines faithfully, unless it is a line for MEDPLUM_TOKEN.
+            # In that case, store a replacement line with the new token value.
+            # If none of the lines were for the MEDPLUM_TOKEN, append it to the
+            # end.
+            env_file_lines = []
+            token_line_set = False
             if os.path.exists(env_file):
                 with open(env_file, "r") as f:
                     for line in f:
-                        if "=" in line and not line.startswith("#"):
+                        if line.startswith("#") or line.strip() == "":
+                            env_file_lines.append(line)
+                        elif "=" in line:
                             key, value = line.strip().split("=", 1)
-                            env_vars[key] = value
+                            if key == "MEDPLUM_TOKEN":
+                                updated_token_line = f"MEDPLUM_TOKEN={token}\n"
+                                env_file_lines.append(updated_token_line)
+                                token_line_set = True
+                            else:
+                                env_file_lines.append(line)
+            if not token_line_set:
+                env_file_lines.append(f"MEDPLUM_TOKEN={token}\n")
             
-            # Update token and write back
-            env_vars["MEDPLUM_TOKEN"] = token
-            
+            # Write the updated env file
             with open(env_file, "w") as f:
-                for key, value in env_vars.items():
-                    f.write(f"{key}={value}\n")
+                for line in env_file_lines:
+                    f.write(f"{line}")
             
             print(f"Token saved to {env_file}")
     else:
@@ -117,4 +129,4 @@ def main():
     return 0
 
 if __name__ == "__main__":
-    exit(main()) 
+    exit(main())

--- a/agents/auth/phenoml_auth.py
+++ b/agents/auth/phenoml_auth.py
@@ -91,20 +91,32 @@ def main():
             env_file = ".env"
             
             # Read existing .env file if it exists
-            env_vars = {}
+            # Store all lines faithfully, unless it is a line for PHENOML_TOKEN.
+            # In that case, store a replacement line with the new token value.
+            # If none of the lines were for the PHENOML_TOKEN, append it to the
+            # end.
+            env_file_lines = []
+            token_line_set = False
             if os.path.exists(env_file):
                 with open(env_file, "r") as f:
                     for line in f:
-                        if "=" in line and not line.startswith("#"):
+                        if line.startswith("#") or line.strip() == "":
+                            env_file_lines.append(line)
+                        elif "=" in line:
                             key, value = line.strip().split("=", 1)
-                            env_vars[key] = value
+                            if key == "PHENOML_TOKEN":
+                                updated_token_line = f"PHENOML_TOKEN={token}\n"
+                                env_file_lines.append(updated_token_line)
+                                token_line_set = True
+                            else:
+                                env_file_lines.append(line)
+            if not token_line_set:
+                env_file_lines.append(f"PHENOML_TOKEN={token}\n")
             
-            # Update token and write back
-            env_vars["PHENOML_TOKEN"] = token
-            
+            # Write the updated env file
             with open(env_file, "w") as f:
-                for key, value in env_vars.items():
-                    f.write(f"{key}={value}\n")
+                for line in env_file_lines:
+                    f.write(f"{line}")
             
             print(f"Token saved to {env_file}")
     else:
@@ -114,4 +126,4 @@ def main():
     return 0
 
 if __name__ == "__main__":
-    exit(main()) 
+    exit(main())


### PR DESCRIPTION
- Formalizes the expected `.env` file
- Preserves newlines and comments in the `.env` when writing tokens
- Adds the ability to make requests to Canvas FHIR servers
- Adds instructions for using with Canvas to the README

**Caution!**
I do not have PhenoML credentials, so was not able to confirm end-to-end functionality. I **was** able to confirm the changes I made to `auth/canvas_auth.py` are working as expected, and thus have confidence in the similar changes I made to the other `_auth.py` files.